### PR TITLE
[READY] Clone the LLVM repo instead of using individual archives

### DIFF
--- a/.github/workflows/package_llvm.yml
+++ b/.github/workflows/package_llvm.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
It works, even if it takes >5hr.

Next step to automating the update of clang is to extract the repackaging part of ycmd/update_clang.py into a separate workflow in this repo. That would leave only the LLVM headers update in ycmd, as that needs an actual commit and a pull request.

For the second part, here are a few questions:

1. Should we merge the two scripts and just have a switch like `--big-upload`/`--small-upload` or should we keep the scripts spearate?
2. `package.yml` is using `requests` while `update_clang.py` right now is using `urllib`. Assuming I can get urllib authentication to work, which would we prefer?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/llvm/2)
<!-- Reviewable:end -->
